### PR TITLE
better compatibility

### DIFF
--- a/fio.js
+++ b/fio.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 const net = require('net')
 const fs = require('fs')
 


### PR DESCRIPTION
incase node not installed at `/usr/bin/node`.


refers
https://en.wikipedia.org/wiki/Shebang_(Unix)
https://stackoverflow.com/questions/33509816/what-exactly-does-usr-bin-env-node-do-at-the-beginning-of-node-files